### PR TITLE
cmake で OS X とそれ以外でリンクするライブラリを変更するようにした

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,11 @@ project(life)
 add_executable(life life.cc cell.cc cellset.cc)
 set(CMAKE_BUILD_TYPE Release)
 
-target_link_libraries(life ncursesw)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  target_link_libraries(life ncurses)
+else()
+  target_link_libraries(life ncursesw)
+endif()
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")


### PR DESCRIPTION
OS X だと ncurses が直接 UTF-8 扱えるようになっているみたいなので, OS X だけ直接 ncurses をリンクするように変更